### PR TITLE
Fix navigation highlight persisting outside sections

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -36,22 +36,24 @@ export function Header() {
       setIsScrolled(window.scrollY > 50);
 
       // Active section detection
-      const sections = navItems.map((item) => item.href.substring(1));
-      const headerHeight = 80; // Fixed header height
-      const buffer = 10; // Small buffer for reliable detection
-      const scrollPosition = window.scrollY + headerHeight + buffer;
+        const sections = navItems.map((item) => item.href.substring(1));
+        const headerHeight = 80; // Fixed header height
+        const buffer = 10; // Small buffer for reliable detection
+        const scrollPosition = window.scrollY + headerHeight + buffer;
 
-      for (const section of sections) {
-        const element = document.getElementById(section);
-        if (element && element instanceof HTMLElement) {
-          const { offsetTop, offsetHeight } = element;
-          if (scrollPosition >= offsetTop && scrollPosition < offsetTop + offsetHeight) {
-            setActiveSection(section);
-            break;
+        let currentSection = '';
+        for (const section of sections) {
+          const element = document.getElementById(section);
+          if (element && element instanceof HTMLElement) {
+            const { offsetTop, offsetHeight } = element;
+            if (scrollPosition >= offsetTop && scrollPosition < offsetTop + offsetHeight) {
+              currentSection = section;
+              break;
+            }
           }
         }
-      }
-    };
+        setActiveSection(currentSection);
+      };
 
     window.addEventListener('scroll', handleScroll);
     handleScroll(); // Call once to set initial state


### PR DESCRIPTION
## Summary
- ensure header navigation resets active section when user scrolls away from tracked sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ce0bf9348323bee58fc2a22b72f2